### PR TITLE
Fix crash caused when exiting.

### DIFF
--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -47,6 +47,7 @@ wxFrame::wxFrame( wxWindow *parent, wxWindowID id, const wxString& title,
 wxFrame::~wxFrame()
 {
     // central widget should be deleted by qt when the main window is destroyed
+    QtStoreWindowPointer( m_qtMainWindow->centralWidget(), NULL );
 }
 
 bool wxFrame::Create( wxWindow *parent, wxWindowID id, const wxString& title,


### PR DESCRIPTION
The lost focus event was triggered to the central widget.
Since this widget does not map to a qt widget, there is
no wxWindow derived destructor for it, so the handler
must be set to NULL from the frame.
