### PR TITLE
allow handler to work from constructors of classes like filedialog

### DIFF
--- a/src/qt/dialog.cpp
+++ b/src/qt/dialog.cpp
@@ -80,6 +80,6 @@ bool wxDialog::IsModal() const
 
 QDialog *wxDialog::GetHandle() const
 {
-    return m_qtDialog;
+    return static_cast<QDialog*>(m_qtWindow);
 }
 


### PR DESCRIPTION
we should do this for all the classes
